### PR TITLE
ci: auto-merge Dependabot patch/minor bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: dependabot auto-merge
+
+# Enable auto-merge on Dependabot PRs for patch/minor bumps. Auto-merge waits for
+# the required status checks (branch protection on main) before merging, so a bump
+# that breaks CI is never merged. Major bumps are left for manual review.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch/minor
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml`: enables auto-merge (squash) on Dependabot PRs for **patch/minor** updates only, using `dependabot/fetch-metadata` to classify the bump. Major bumps stay manual.

Paired repo settings (applied out-of-band):
- Repo **Allow auto-merge** enabled.
- Branch protection on `main`: required status checks `stylua` + `test (stable)` (nightly excluded so upstream Neovim breakage can't block merges); no required reviews; admins not enforced.

So a Dependabot patch/minor PR now: opens → CI runs → if green, merges itself; if red, waits.

https://claude.ai/code/session_01E3sU9jLT1QiC5pLGZjvjGp