### PR TITLE
ci: harden workflows and add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately via
+[GitHub's private vulnerability reporting](https://github.com/dpezto/chezmoi-template.nvim/security/advisories/new)
+rather than filing a public issue.
+
+Since this is a Neovim plugin (no server component, no secrets handled at
+runtime beyond what `chezmoi` itself manages), the main risk surface is:
+
+- Arbitrary code execution via a malicious `.tmpl` file being parsed/rendered
+- Supply-chain issues in CI (GitHub Actions dependencies)
+
+Expect an initial response within a few days; this is a solo-maintained project.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,21 @@ on:
     # weekly run so nvim-nightly API drift surfaces without waiting for a push
     - cron: "0 6 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: reviewdog/action-actionlint@50842263c20a7c46bd0065b9e624d3c569db061e # v1
+
   stylua:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: JohnnyMorganz/stylua-action@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: JohnnyMorganz/stylua-action@76fd70c03e6340ceaf673366712db9b20560b402 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
@@ -25,8 +34,8 @@ jobs:
       matrix:
         neovim: [stable, nightly]
     steps:
-      - uses: actions/checkout@v7
-      - uses: rhysd/action-setup-vim@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: rhysd/action-setup-vim@febef33995d6649302e9d88dda81e071b68f16a7 # v1
         with:
           neovim: true
           version: ${{ matrix.neovim }}
@@ -45,7 +54,7 @@ jobs:
           "$HOME/.luarocks/bin/luacov" -r lcov
           sed -i "s|^SF:$GITHUB_WORKSPACE/|SF:|" luacov.report.out
       - if: matrix.neovim == 'stable'
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: luacov.report.out
@@ -59,6 +68,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           release-type: simple

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for patch/minor

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: codelytv/pr-size-labeler@v1
+      - uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
         with:
           xs_label: "size/xs"
           xs_max_size: "3"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
   title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Supply-chain / CI hardening (authored in a separate session, committed here).

- Pin all GitHub Actions to full commit SHAs.
- Add an `actionlint` job (reviewdog).
- Set least-privilege `permissions: contents: read` on CI.
- Dependabot: 5-day cooldown.
- Add `SECURITY.md` (private vulnerability reporting + risk surface).

No plugin code touched.

https://claude.ai/code/session_01E3sU9jLT1QiC5pLGZjvjGp