### PR TITLE
feat: close gaps vs chezmoi.nvim / chezmoi.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Most chezmoi integrations wrap the `chezmoi edit` CLI: temporary buffers, watche
 - **`%` matching for template delimiters** ([vim-matchup](https://github.com/andymass/vim-matchup)). `{{ if }}` ⇄ `{{ else }}` ⇄ `{{ end }}`, including `{{-` trim markers.
 - **Live template preview.** `:Chezmoi preview` renders the buffer through `chezmoi execute-template` into a split typed as the target filetype, re-rendered live as you type (debounced). Invalid syntax keeps the last valid render — flagged stale in the winbar — until it parses again. `q` (or toggling again) closes it.
 - **Template diagnostics.** Errors from `chezmoi execute-template` surface as `vim.diagnostic` entries on write — template typos stop being invisible until apply fails.
-- **Commands.** One `:Chezmoi` command with subcommands (tab-completed): `apply` (buffer target, or `:Chezmoi! apply` for all; apply-on-save on by default), `diff`, `target` (`:Chezmoi! target` opens the deployed file), `source` (jump from a deployed file to its source; opt-in automatic redirect), `preview`, `pick` (source-file picker: snacks / telescope / fzf-lua / mini.pick / `vim.ui.select`).
+- **Commands.** One `:Chezmoi` command with subcommands (tab-completed): `apply` (buffer target, or `:Chezmoi! apply` for all; apply-on-save on by default), `diff`, `target` (`:Chezmoi! target` opens the deployed file), `source` (jump from a deployed file to its source; opt-in automatic redirect), `edit` (`:Chezmoi edit <target>` opens the source for any deploy target, tab-completing target paths), `preview`, `pick` (source-file picker: snacks / telescope / fzf-lua / mini.pick / `vim.ui.select`).
 - **Completion** ([blink.cmp](https://github.com/Saghen/blink.cmp)). Context-aware inside `{{ … }}` via the gotmpl treesitter tree: after a dot (`.foo`) it offers only data keys from `chezmoi data` (icons reflect each value's type, docs preview the value); at command position it adds template/sprig/chezmoi functions and Go template keywords; inside string literals it stays quiet. Outside actions: block snippets — `if`, `if/else`, `range`, `with`, `define`, `block`, comments — expanding to full `{{- … }}…{{- end }}` pairs. Falls back to a line heuristic when the gotmpl parser isn't installed.
 
 ![:Chezmoi preview — live rendered template in a split, re-rendered as you type](assets/preview.gif)
@@ -104,7 +104,10 @@ Defaults:
 ```lua
 require("chezmoi-template").setup({
   source_dir = nil,            -- nil = auto-detect via `chezmoi source-path`
-  inject = { enabled = true }, -- treesitter injection of the target language
+  inject = {
+    enabled = true,            -- treesitter injection of the target language
+    exclude = {},              -- lua patterns for source paths to leave as plain gotmpl
+  },
   format = {
     enabled = true,            -- conform formatter registration
     indent_directives = true,  -- depth-pad column-0 `{{-` directive blocks
@@ -113,6 +116,7 @@ require("chezmoi-template").setup({
   apply = {
     on_save = true,            -- chezmoi apply <target> after writing a source file
     notify = true,             -- notify on successful applies (failures always notify)
+    force = false,             -- pass --force (skip chezmoi's prompt on modified targets)
   },
   preview = {
     live = true,               -- :Chezmoi preview re-renders as you type (false = on write)
@@ -214,6 +218,20 @@ The source only activates in gotmpl buffers. Inside `{{ … }}` it narrows by cu
 ```lua
 keys = { { "<leader>sz", "<cmd>Chezmoi pick<cr>", desc = "Chezmoi source files" } },
 ```
+
+## Lua API
+
+For statuslines, custom pickers, or scripts:
+
+```lua
+-- every managed file as { source = <abs>, target = <abs> } pairs
+local files = require("chezmoi-template").list()
+
+-- open the chezmoi source for a deploy target (~ is expanded)
+require("chezmoi-template").edit("~/.zshrc")
+```
+
+`edit(target)` is the programmatic form of `:Chezmoi edit <target>`.
 
 ## Secrets
 

--- a/lua/chezmoi-template/commands.lua
+++ b/lua/chezmoi-template/commands.lua
@@ -22,6 +22,9 @@ end
 -- chezmoi apply, whole state or a single target (async)
 local function apply(target)
   local cmd = { "chezmoi", "apply" }
+  if require("chezmoi-template").config.apply.force then
+    table.insert(cmd, "--force")
+  end
   if target then
     table.insert(cmd, target)
   end
@@ -338,11 +341,33 @@ local subcommands = {
       if resolve.is_managed(file) then
         return notify("already in the chezmoi source directory")
       end
-      local ret = vim.system({ "chezmoi", "source-path", file }, { text = true }):wait()
-      if ret.code ~= 0 then
+      local src = resolve.source_path(file)
+      if not src then
         return notify("not a chezmoi-managed file", vim.log.levels.WARN)
       end
-      vim.cmd.edit(vim.fn.fnameescape(vim.trim(ret.stdout)))
+      vim.cmd.edit(vim.fn.fnameescape(src))
+    end,
+  },
+
+  edit = {
+    desc = "open the chezmoi source for a target path",
+    run = function(ctx)
+      local target = ctx.fargs[1]
+      if not target or target == "" then
+        return notify("usage: :Chezmoi edit <target>", vim.log.levels.WARN)
+      end
+      require("chezmoi-template").edit(target)
+    end,
+    complete = function(arglead)
+      local expanded = vim.fn.expand(arglead)
+      local out = {}
+      for t in pairs(resolve.managed_set()) do -- cached absolute target paths
+        if arglead == "" or t:find(expanded, 1, true) == 1 then
+          out[#out + 1] = t
+        end
+      end
+      table.sort(out)
+      return out
     end,
   },
 
@@ -369,12 +394,19 @@ local function define_commands()
     if not entry then
       return notify(("usage: :Chezmoi <%s>"):format(table.concat(sub_names, "|")), vim.log.levels.WARN)
     end
-    entry.run({ bang = o.bang })
+    entry.run({ bang = o.bang, fargs = vim.list_slice(o.fargs, 2) })
   end, {
     bang = true,
     nargs = "*",
     desc = "chezmoi-template",
-    complete = function(arglead)
+    complete = function(arglead, cmdline)
+      -- Word 2 is the subcommand; past it, delegate to its value completion.
+      local words = vim.split(vim.trim(cmdline), "%s+")
+      local sub = words[2]
+      local entry = sub and subcommands[sub]
+      if entry and entry.complete and (sub ~= arglead) then
+        return entry.complete(arglead)
+      end
       return vim.tbl_filter(function(n)
         return n:find(arglead, 1, true) == 1
       end, sub_names)
@@ -431,11 +463,10 @@ function M.setup()
         if not resolve.managed_set()[abs] then
           return
         end
-        local ret = vim.system({ "chezmoi", "source-path", abs }, { text = true }):wait()
-        if ret.code ~= 0 then
+        local src = resolve.source_path(abs)
+        if not src then
           return
         end
-        local src = vim.trim(ret.stdout)
         vim.schedule(function()
           if vim.api.nvim_get_current_buf() == ctx.buf then
             vim.cmd.edit(vim.fn.fnameescape(src))

--- a/lua/chezmoi-template/init.lua
+++ b/lua/chezmoi-template/init.lua
@@ -4,7 +4,11 @@ M.config = {
   -- nil = auto-detect via `chezmoi source-path`
   source_dir = nil,
   -- treesitter injection of the deployed target language into *.tmpl buffers
-  inject = { enabled = true },
+  inject = {
+    enabled = true,
+    -- lua patterns for source paths to leave as plain gotmpl (no target injection)
+    exclude = {},
+  },
   -- conform.nvim formatter that formats templates as their target filetype
   format = {
     enabled = true,
@@ -14,8 +18,9 @@ M.config = {
   },
   -- resolve chezmoi source names to target icons in mini.icons
   icons = { enabled = true },
-  -- run `chezmoi apply <target>` after writing a managed source file
-  apply = { on_save = true, notify = true },
+  -- run `chezmoi apply <target>` after writing a managed source file.
+  -- force = pass --force (skip chezmoi's prompt on externally-modified targets).
+  apply = { on_save = true, notify = true, force = false },
   -- :Chezmoi preview rendered preview. live = re-render as you type (debounced,
   -- ms); false = re-render on write only. Invalid syntax keeps the last valid
   -- render until it parses again. slow_ms: if a render takes longer than this,
@@ -46,7 +51,7 @@ M.config = {
 
 -- Static subcommand names for pre-activation tab-completion; the real command
 -- (commands.lua) derives its own from the handler table. Kept in sync by hand.
-local SUBCOMMANDS = { "apply", "diff", "pick", "preview", "source", "target" }
+local SUBCOMMANDS = { "apply", "diff", "edit", "pick", "preview", "source", "target" }
 
 -- setup() is cheap: it only registers filetype detection, the treesitter
 -- injection directive, and light triggers. The heavy work (module requires,
@@ -172,6 +177,25 @@ function M._activate()
       end, 100)
     end,
   })
+end
+
+-- Public API for integrations (statuslines, custom pickers, scripts).
+
+-- All managed files as { source = <abs>, target = <abs> } pairs.
+function M.list()
+  M._activate()
+  return require("chezmoi-template.resolve").list()
+end
+
+-- Open the chezmoi source file for a deploy target path.
+function M.edit(target)
+  M._activate()
+  local src = require("chezmoi-template.resolve").source_path(vim.fn.expand(target))
+  if not src then
+    vim.notify(target .. " is not chezmoi-managed", vim.log.levels.WARN, { title = "chezmoi" })
+    return
+  end
+  vim.cmd.edit(vim.fn.fnameescape(src))
 end
 
 return M

--- a/lua/chezmoi-template/inject.lua
+++ b/lua/chezmoi-template/inject.lua
@@ -46,6 +46,12 @@ function M.seed_buffer(buf, file)
   if not resolve.is_managed(file) then
     return
   end
+  -- Excluded paths stay plain gotmpl (no target-language injection).
+  for _, pat in ipairs(require("chezmoi-template").config.inject.exclude) do
+    if file:match(pat) then
+      return
+    end
+  end
   -- No deploy target (.chezmoitemplates/ partials, .chezmoiscripts/):
   -- infer from the attribute-stripped basename (run_once_foo.sh.tmpl -> foo.sh).
   -- The prefetched source set (one spawn per session) skips the doomed

--- a/lua/chezmoi-template/resolve.lua
+++ b/lua/chezmoi-template/resolve.lua
@@ -23,13 +23,25 @@ function M.resolve_path(name)
   end
   local parts = {}
   for part in name:sub(#prefix + 1):gmatch("[^/]+") do
+    -- literal_ ends attribute parsing: strip it and take the rest verbatim
+    -- (chezmoi does NOT interpret dot_/.tmpl/etc. after it — literal_dot_x -> dot_x).
+    local literal = false
     local changed = true
     while changed do
       changed = false
+      if part:match("^literal_") then
+        part = part:sub(#"literal_" + 1)
+        literal = true
+        break
+      end
       local new_part = part
         :gsub("^private_", "")
         :gsub("^readonly_", "")
         :gsub("^executable_", "")
+        :gsub("^create_", "")
+        :gsub("^modify_", "")
+        :gsub("^remove_", "")
+        :gsub("^symlink_", "")
         :gsub("^run_once_", "")
         :gsub("^run_onchange_", "")
         :gsub("^run_", "")
@@ -41,7 +53,9 @@ function M.resolve_path(name)
         changed = true
       end
     end
-    part = part:gsub("^dot_", "."):gsub("%.age$", ""):gsub("%.asc$", ""):gsub("%.tmpl$", "")
+    if not literal then
+      part = part:gsub("^dot_", "."):gsub("%.age$", ""):gsub("%.asc$", ""):gsub("%.tmpl$", "")
+    end
     table.insert(parts, part)
   end
   return prefix .. table.concat(parts, "/")
@@ -172,6 +186,63 @@ function M.source_set()
     source_set_cache = managed_listing("source-absolute") or false
   end
   return source_set_cache or nil
+end
+
+-- Ordered array of normalized paths for a managed listing style, or nil.
+local function managed_array(style)
+  if not M.has_chezmoi() then
+    return nil
+  end
+  local ret = vim.system({ "chezmoi", "managed", "--path-style", style, "--include", "files" }, { text = true }):wait()
+  if ret.code ~= 0 then
+    return nil
+  end
+  local arr = {}
+  for line in ret.stdout:gmatch("[^\n]+") do
+    arr[#arr + 1] = vim.fs.normalize(line)
+  end
+  return arr
+end
+
+-- Public: all managed files as { source = <abs>, target = <abs> } pairs.
+-- `managed` sorts the two path-styles by different keys, so they can't be
+-- zipped by index; instead resolve every target's source in one
+-- `source-path <t1> <t2> …` spawn, which emits sources in argument order.
+-- Uncached (rare call).
+function M.list()
+  local targets = managed_array("absolute")
+  if not targets or #targets == 0 then
+    return {}
+  end
+  -- ponytail: all targets in one argv; fine for normal repos, could hit ARG_MAX
+  -- with thousands of long paths — batch if that ever bites.
+  local cmd = { "chezmoi", "source-path" }
+  vim.list_extend(cmd, targets)
+  local ret = vim.system(cmd, { text = true }):wait()
+  if ret.code ~= 0 then
+    return {}
+  end
+  local sources = {}
+  for line in ret.stdout:gmatch("[^\n]+") do
+    sources[#sources + 1] = vim.fs.normalize(line)
+  end
+  local out = {}
+  for i, target in ipairs(targets) do
+    out[i] = { source = sources[i], target = target }
+  end
+  return out
+end
+
+-- Source path for a deploy target via `chezmoi source-path`, or nil.
+function M.source_path(target)
+  if not M.has_chezmoi() then
+    return nil
+  end
+  local ret = vim.system({ "chezmoi", "source-path", target }, { text = true }):wait()
+  if ret.code ~= 0 then
+    return nil
+  end
+  return vim.trim(ret.stdout)
 end
 
 -- Render template text through `chezmoi execute-template` (async).

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -304,6 +304,13 @@ eq(
   "/src/.config/secrets.json"
 )
 eq("resolve_path relative stays relative", resolve.resolve_path("dot_config/foo.toml.tmpl"), ".config/foo.toml")
+eq("resolve_path symlink_", resolve.resolve_path("symlink_dot_foo"), ".foo")
+eq("resolve_path create_", resolve.resolve_path("create_dot_bar"), ".bar")
+eq("resolve_path modify_", resolve.resolve_path("modify_dot_baz.tmpl"), ".baz")
+eq("resolve_path remove_", resolve.resolve_path("remove_dot_qux"), ".qux")
+-- literal_ ends attribute parsing: dot_ stays literal (matches real chezmoi)
+eq("resolve_path literal_ keeps rest verbatim", resolve.resolve_path("literal_dot_quux"), "dot_quux")
+eq("resolve_path prefix before literal_ still strips", resolve.resolve_path("private_literal_dot_q"), "dot_q")
 eq("invalidate clears without error", pcall(resolve.invalidate), true)
 
 -- formatter resolves target ft from the buffer name when unseeded (BufNewFile)
@@ -335,6 +342,7 @@ local SRC = vim.fn.getcwd() .. "/tests" -- source_dir configured in minimal_init
 
 local fake = {} -- subcommand -> canned vim.system result
 local spawns = {} -- subcommand -> call count
+local sent = {} -- subcommand -> full cmd array of the last spawn (for flag asserts)
 local real_system = vim.system
 ---@diagnostic disable-next-line: duplicate-set-field
 vim.system = function(cmd, _, cb)
@@ -343,6 +351,7 @@ vim.system = function(cmd, _, cb)
   end
   local key = cmd[2]
   spawns[key] = (spawns[key] or 0) + 1
+  sent[key] = cmd
   local ret = vim.deepcopy(fake[key] or { code = 1, stdout = "", stderr = "no fake for " .. key })
   if cb then
     cb(ret)
@@ -754,6 +763,59 @@ do
   vim.health = real_health
   eq("health reports run", #reports >= 4, true)
   eq("health mentions chezmoi binary", reports[2]:find("chezmoi executable", 1, true) ~= nil, true)
+end
+
+-- apply.force appends --force to the apply command
+do
+  local fb = vim.api.nvim_create_buf(true, false)
+  vim.api.nvim_buf_set_name(fb, SRC .. "/dot_force.tmpl")
+  vim.api.nvim_set_current_buf(fb)
+  fake["apply"] = { code = 0, stdout = "" }
+  fake["target-path"] = { code = 0, stdout = SRC .. "/.force\n" }
+  ct.config.apply.force = true
+  clear_notes()
+  vim.cmd("Chezmoi apply")
+  vim.wait(1000, function()
+    return has_note("applied")
+  end)
+  eq("apply.force passes --force", vim.tbl_contains(sent["apply"], "--force"), true)
+  ct.config.apply.force = false
+  vim.api.nvim_buf_delete(fb, { force = true })
+end
+
+-- list() pairs each target (from `managed --path-style absolute`) with its
+-- source (from a single `source-path <t1> <t2> …` spawn, emitted in arg order).
+do
+  fake["managed"] = { code = 0, stdout = "/home/u/.zshrc\n/home/u/.gitconfig\n" }
+  fake["source-path"] = { code = 0, stdout = SRC .. "/dot_zshrc.tmpl\n" .. SRC .. "/dot_gitconfig\n" }
+  resolve.invalidate()
+  local files = ct.list()
+  eq("list returns one entry per managed file", #files, 2)
+  eq("list pairs source with its target", files[1].source, SRC .. "/dot_zshrc.tmpl")
+  eq("list carries target", files[1].target, "/home/u/.zshrc")
+  eq("list keeps arg order for the second entry", files[2].source, SRC .. "/dot_gitconfig")
+end
+
+-- edit(target) opens the resolved source file
+do
+  fake["source-path"] = { code = 0, stdout = SRC .. "/dot_gitconfig.tmpl\n" }
+  ct.edit("~/.gitconfig")
+  eq("edit opens the resolved source", vim.api.nvim_buf_get_name(0), SRC .. "/dot_gitconfig.tmpl")
+end
+
+-- inject.exclude leaves matching source paths as plain gotmpl (no target lang)
+do
+  fake["managed"] = { code = 0, stdout = "" } -- empty set -> name-based ft fallback
+  resolve.invalidate()
+  ct.config.inject.exclude = { "excluded%.json%.tmpl" }
+  local xb = vim.api.nvim_create_buf(false, true)
+  require("chezmoi-template.inject").seed_buffer(xb, SRC .. "/dot_excluded.json.tmpl")
+  eq("inject.exclude skips target injection", vim.b[xb].chezmoi_target_lang, nil)
+  eq("inject.exclude skips target ft", vim.b[xb].chezmoi_target_ft, nil)
+  local yb = vim.api.nvim_create_buf(false, true)
+  require("chezmoi-template.inject").seed_buffer(yb, SRC .. "/dot_included.json.tmpl")
+  eq("non-excluded still seeds target ft", vim.b[yb].chezmoi_target_ft, "json")
+  ct.config.inject.exclude = {}
 end
 
 -- flush coverage stats before exit (`nvim -l` may skip luacov's exit hook)


### PR DESCRIPTION
Adds the parity/correctness features the competitor plugins had that this one lacked.

## Changes
- **resolve_path**: strip `create_`/`modify_`/`remove_`/`symlink_` source-state attributes, and handle `literal_` correctly (it ends attribute parsing — the rest, including `dot_`, stays verbatim, matching chezmoi). Fixes icon/preview name resolution for those files.
- **inject.exclude**: lua patterns for source paths to leave as plain gotmpl (no target-language injection), mirroring `encryption.exclude`.
- **apply.force**: pass `--force` to `chezmoi apply`.
- **Public Lua API**: `list()` → `{ source, target }` pairs, and `edit(target)` + a `:Chezmoi edit <target>` command (tab-completes target paths). `list()` resolves every source in one `source-path` spawn (the two managed path-styles sort differently and cannot be zipped by index).
- `resolve.source_path()` centralizes source-path lookups; the `source` subcommand and `redirect` autocmd route through it (keeps all chezmoi calls in resolve.lua).

## Verification
- `make test` + `stylua --check` green (14 new test cases).
- Verified against real chezmoi over 208 managed files: `list()` alignment, `resolve_path` parity, `edit`, `inject.exclude`, and `apply --force` all confirmed.

https://claude.ai/code/session_01Ge1qZGDxS87aRk8dAvJCeH