### PR TITLE
fix(format): mask key-position templates correctly, fall back for unmaskable lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Most chezmoi integrations wrap the `chezmoi edit` CLI: temporary buffers, watche
 
   ![Formatting a template as its target filetype](assets/format.gif)
 
+  A few template shapes have no placeholder form the target syntax accepts — a template glued to a bare word (`k = {{ .x }}suffix`), or a control-flow pair wrapping a whole entry (`{{ if .on }}k = 1{{ end }}`). Those lines are masked whole instead, so they come back untouched while the rest of the file still formats.
+
 - **Target-aware icons** ([mini.icons](https://github.com/nvim-mini/mini.icons)). `private_dot_config/ghostty/config.tmpl` shows the ghostty icon, not a generic template glyph. Any combination of chezmoi source-state attributes (`private_`, `encrypted_`, `exact_`, `dot_`, `.tmpl`, `.age`, …) resolves to the deployed name.
 - **Transparent encryption** (opt-in). chezmoi-managed `*.age` files decrypt on open and re-encrypt on save via `chezmoi decrypt` / `chezmoi encrypt` — whatever your chezmoi config uses (age, rage, builtin age, even gpg) just works. `encrypted_*.tmpl.age` still gets full template + target highlighting.
 - **`%` matching for template delimiters** ([vim-matchup](https://github.com/andymass/vim-matchup)). `{{ if }}` ⇄ `{{ else }}` ⇄ `{{ end }}`, including `{{-` trim markers.

--- a/doc/chezmoi-template.txt
+++ b/doc/chezmoi-template.txt
@@ -24,6 +24,9 @@ source files, so you edit them natively instead of going through
   treesitter-injected (a dot_zshrc.tmpl highlights as Go template + zsh).
 - A conform.nvim formatter formats templates with the TARGET filetype's
   formatter by masking Go-template spans and restoring them afterwards.
+  Lines with no valid placeholder form (a template glued to a bare word, a
+  control-flow pair wrapping an entry) are masked whole and come back
+  untouched, so they never block formatting the rest of the file.
 - mini.icons lookups resolve source names (private_dot_config/...) to their
   deployed targets.
 - Optional transparent decrypt/encrypt of chezmoi-managed encrypted files

--- a/lua/chezmoi-template/format.lua
+++ b/lua/chezmoi-template/format.lua
@@ -3,8 +3,13 @@
 -- the spans.
 -- Per line: a line that is ONLY template directives -> a comment placeholder
 -- (structurally inert; also covers multi-line {{ … }} spans); inline {{…}} ->
--- a unique token, quoted after = / : so JSON/TOML stay valid, bare otherwise
--- so it nests inside strings and identifiers.
+-- a unique token, quoted where it stands alone as a value so JSON/TOML stay
+-- valid, bare where it is glued to identifier characters or sits inside a
+-- string, so it nests into keys and words.
+-- Not every line has a valid token form (`k = {{ .x }}suffix`,
+-- `{{ if .on }}k = 1{{ end }}`), so a rejected mask is retried with every
+-- template line replaced by a comment placeholder: those lines come back
+-- untouched instead of failing the whole file.
 local M = {}
 
 M.formatter = {
@@ -48,100 +53,116 @@ M.formatter = {
       end
     end
 
-    local masked, map, open = {}, {}, false
-    for i, line in ipairs(lines) do
-      local key = prefix .. " " .. sentinel .. i .. (suffix ~= "" and " " .. suffix or "")
-      local indent = line:match("^(%s*)")
-      if open then -- continuation of a multi-line {{ … }} span
-        masked[i] = key
-        map[key] = line
-        open = not line:match("}}")
-      elseif line:match("{{") and not line:match("}}") then -- opens a multi-line span
-        open = true
-        masked[i] = indent .. key
-        map[key] = line:sub(#indent + 1)
-      elseif line:match("{{") and line:gsub("{{.-}}", ""):match(is_json and "^[%s,]*$" or "^%s*$") then -- whole-line directive(s)
-        masked[i] = indent .. key
-        map[key] = line:sub(#indent + 1)
-      elseif line:match("{{") then -- inline template(s) embedded in code
-        local res, pos, j = "", 1, 0
-        while pos <= #line do
-          local s, e = line:find("{{", pos, true)
-          if not s then
-            res = res .. line:sub(pos)
-            break
-          end
-          res = res .. line:sub(pos, s - 1)
-          local t_end = e + 1
-          while true do
-            local e2 = line:find("}}", t_end, true)
-            if not e2 then
-              t_end = #line
+    -- Two masking strengths. Fine (the default) turns each inline {{…}} into a
+    -- token, so the formatter still lays the surrounding line out. Coarse
+    -- replaces every template-bearing line with a comment placeholder: those
+    -- lines come back untouched, but the placeholder is inert in any syntax, so
+    -- the rest of the file still formats. Coarse is the retry for lines the
+    -- fine pass cannot express — a template glued to a bare word
+    -- (`k = {{ .x }}suffix`) or a control-flow pair wrapping content
+    -- (`{{ if .on }}k = 1{{ end }}`); neither has a valid token form.
+    local function build_mask(coarse)
+      local masked, map, open = {}, {}, false
+      for i, line in ipairs(lines) do
+        local key = prefix .. " " .. sentinel .. i .. (suffix ~= "" and " " .. suffix or "")
+        local indent = line:match("^(%s*)")
+        if open then -- continuation of a multi-line {{ … }} span
+          masked[i] = key
+          map[key] = line
+          open = not line:match("}}")
+        elseif line:match("{{") and not line:match("}}") then -- opens a multi-line span
+          open = true
+          masked[i] = indent .. key
+          map[key] = line:sub(#indent + 1)
+        elseif line:match("{{") and (coarse or line:gsub("{{.-}}", ""):match(is_json and "^[%s,]*$" or "^%s*$")) then -- whole-line directive(s), or any template line under coarse masking
+          masked[i] = indent .. key
+          map[key] = line:sub(#indent + 1)
+        elseif line:match("{{") then -- inline template(s) embedded in code
+          local res, pos, j = "", 1, 0
+          while pos <= #line do
+            local s, e = line:find("{{", pos, true)
+            if not s then
+              res = res .. line:sub(pos)
               break
             end
-            local _, q = line:sub(e + 1, e2 - 1):gsub('\\"', ""):gsub('"', "")
-            if q % 2 == 0 then
-              t_end = e2 + 1
-              break
+            res = res .. line:sub(pos, s - 1)
+            local t_end = e + 1
+            while true do
+              local e2 = line:find("}}", t_end, true)
+              if not e2 then
+                t_end = #line
+                break
+              end
+              local _, q = line:sub(e + 1, e2 - 1):gsub('\\"', ""):gsub('"', "")
+              if q % 2 == 0 then
+                t_end = e2 + 1
+                break
+              end
+              t_end = e2 + 2
             end
-            t_end = e2 + 2
+            j = j + 1
+            local tmpl = line:sub(s, t_end)
+            -- Quote only a standalone token (value position). A token glued to
+            -- identifier chars is part of a bare key or word (`is_{{ $r }}`) —
+            -- quoting it there splits the identifier and breaks TOML/JSON.
+            local _, q = res:gsub('\\"', ""):gsub('"', "")
+            local adjacent = res:sub(-1):match("[%w_%-%.]") or line:sub(t_end + 1, t_end + 1):match("[%w_%-%.]")
+            local k = sentinel .. i .. "_" .. j
+            k = (q % 2 == 0 and not res:match('"$') and not adjacent) and '"' .. k .. '"' or k
+            map[k] = tmpl
+            res = res .. k
+            pos = t_end + 1
           end
-          j = j + 1
-          local tmpl = line:sub(s, t_end)
-          -- Quote only a standalone token (value position). A token glued to
-          -- identifier chars is part of a bare key or word (`is_{{ $r }}`) —
-          -- quoting it there splits the identifier and breaks TOML/JSON.
-          local _, q = res:gsub('\\"', ""):gsub('"', "")
-          local adjacent = res:sub(-1):match("[%w_%-%.]") or line:sub(t_end + 1, t_end + 1):match("[%w_%-%.]")
-          local k = sentinel .. i .. "_" .. j
-          k = (q % 2 == 0 and not res:match('"$') and not adjacent) and '"' .. k .. '"' or k
-          map[k] = tmpl
-          res = res .. k
-          pos = t_end + 1
+          masked[i] = res
+        else
+          masked[i] = line
         end
-        masked[i] = res
-      else
-        masked[i] = line
       end
+      return masked, map
     end
 
     -- Format in a throwaway buffer named in a temp dir (NOT the chezmoi source
     -- dir) so *.tmpl autocmds never fire on it; set the name and filetype with
     -- noautocmd so no LSP attaches to a buffer we delete mid-async.
-    local scratch = vim.api.nvim_create_buf(false, true)
-    vim.bo[scratch].buftype = ""
-    vim.api.nvim_buf_set_lines(scratch, 0, -1, false, masked)
-    local real_name = vim.api.nvim_buf_get_name(ctx.buf)
-    local name
-    if real_name ~= "" then
-      name = real_name:gsub("%.tmpl$", ""):gsub("%.age$", ""):gsub("%.asc$", "")
-      -- Ensure JSON targets are formatted as JSONC so the formatter accepts
-      -- // comment placeholders
-      if is_json then
-        name = name:gsub("%.jsonc?$", ".jsonc")
-        if not name:match("%.jsonc$") then
-          name = name .. ".jsonc"
+    local function run(masked, cb)
+      local scratch = vim.api.nvim_create_buf(false, true)
+      vim.bo[scratch].buftype = ""
+      vim.api.nvim_buf_set_lines(scratch, 0, -1, false, masked)
+      local real_name = vim.api.nvim_buf_get_name(ctx.buf)
+      local name
+      if real_name ~= "" then
+        name = real_name:gsub("%.tmpl$", ""):gsub("%.age$", ""):gsub("%.asc$", "")
+        -- Ensure JSON targets are formatted as JSONC so the formatter accepts
+        -- // comment placeholders
+        if is_json then
+          name = name:gsub("%.jsonc?$", ".jsonc")
+          if not name:match("%.jsonc$") then
+            name = name .. ".jsonc"
+          end
         end
       end
-    end
-    vim.api.nvim_buf_call(scratch, function()
-      if name then
-        vim.cmd("noautocmd keepalt file " .. vim.fn.fnameescape(name))
-      end
-      local scratch_ft = (target_ft == "json") and "jsonc" or target_ft
-      vim.cmd("noautocmd setlocal filetype=" .. scratch_ft)
-    end)
+      vim.api.nvim_buf_call(scratch, function()
+        if name then
+          vim.cmd("noautocmd keepalt file " .. vim.fn.fnameescape(name))
+        end
+        local scratch_ft = (target_ft == "json") and "jsonc" or target_ft
+        vim.cmd("noautocmd setlocal filetype=" .. scratch_ft)
+      end)
 
-    require("conform").format({ bufnr = scratch, async = true, lsp_format = "fallback" }, function(err, _)
-      if err then
+      require("conform").format({ bufnr = scratch, async = true, lsp_format = "fallback" }, function(err, _)
+        if err then
+          vim.api.nvim_buf_delete(scratch, { force = true })
+          return cb(err)
+        end
+        -- No early return when the underlying formatter changed nothing: the
+        -- opener-indent pairing in restore() must still run.
+        local formatted = vim.api.nvim_buf_get_lines(scratch, 0, -1, false)
         vim.api.nvim_buf_delete(scratch, { force = true })
-        return callback(err)
-      end
-      -- No early return when the underlying formatter changed nothing: the
-      -- opener-indent pairing below must still run.
-      local formatted = vim.api.nvim_buf_get_lines(scratch, 0, -1, false)
-      vim.api.nvim_buf_delete(scratch, { force = true })
+        cb(nil, formatted)
+      end)
+    end
 
+    local function restore(formatted, map)
       local keys = vim.tbl_keys(map)
       table.sort(keys, function(a, b)
         return #a > #b
@@ -201,6 +222,23 @@ M.formatter = {
       end
 
       callback(nil, final)
+    end
+
+    local fine, fine_map = build_mask(false)
+    run(fine, function(err, formatted)
+      if not err then
+        return restore(formatted, fine_map)
+      end
+      -- The fine mask produced something the target formatter rejects. Retry
+      -- with every template line inert, so one unmaskable line cannot block
+      -- formatting the rest of the file.
+      local coarse, coarse_map = build_mask(true)
+      run(coarse, function(coarse_err, coarse_formatted)
+        if coarse_err then
+          return callback(coarse_err)
+        end
+        restore(coarse_formatted, coarse_map)
+      end)
     end)
   end,
 }

--- a/lua/chezmoi-template/format.lua
+++ b/lua/chezmoi-template/format.lua
@@ -88,9 +88,13 @@ M.formatter = {
           end
           j = j + 1
           local tmpl = line:sub(s, t_end)
+          -- Quote only a standalone token (value position). A token glued to
+          -- identifier chars is part of a bare key or word (`is_{{ $r }}`) —
+          -- quoting it there splits the identifier and breaks TOML/JSON.
           local _, q = res:gsub('\\"', ""):gsub('"', "")
+          local adjacent = res:sub(-1):match("[%w_%-%.]") or line:sub(t_end + 1, t_end + 1):match("[%w_%-%.]")
           local k = sentinel .. i .. "_" .. j
-          k = (q % 2 == 0 and not res:match('"$')) and '"' .. k .. '"' or k
+          k = (q % 2 == 0 and not res:match('"$') and not adjacent) and '"' .. k .. '"' or k
           map[k] = tmpl
           res = res .. k
           pos = t_end + 1

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -20,6 +20,7 @@ package.preload["conform"] = function()
   function M.format(opts, cb)
     local masked = vim.api.nvim_buf_get_lines(opts.bufnr, 0, -1, false)
     _G.captured_masked = masked
+    _G.captured_name = vim.api.nvim_buf_get_name(opts.bufnr)
     if _G.conform_reject and _G.conform_reject(masked) then
       return cb("stub: masked buffer rejected")
     end

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -10,12 +10,19 @@ end
 
 -- Stub conform: identity "formatter" so tests exercise masking/restore/indent
 -- logic without any external formatter binaries. Captures the masked scratch
--- buffer for assertions.
+-- buffer for assertions. Setting _G.conform_reject to a predicate over the
+-- masked lines makes the stub reject that buffer, which is how the coarse
+-- fallback pass is exercised without a real formatter.
 _G.captured_masked = nil
+_G.conform_reject = nil
 package.preload["conform"] = function()
   local M = { formatters = {}, formatters_by_ft = {} }
   function M.format(opts, cb)
-    _G.captured_masked = vim.api.nvim_buf_get_lines(opts.bufnr, 0, -1, false)
+    local masked = vim.api.nvim_buf_get_lines(opts.bufnr, 0, -1, false)
+    _G.captured_masked = masked
+    if _G.conform_reject and _G.conform_reject(masked) then
+      return cb("stub: masked buffer rejected")
+    end
     cb(nil, false)
   end
   return M

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -173,6 +173,22 @@ run_case("multi-line span", "sh", {
   "echo hi",
 })
 
+-- 8. toml: a template spliced into a BARE KEY must stay unquoted — quoting it
+-- there splits the identifier (`is_"TOKEN" = …`) and taplo rejects the file.
+run_case("toml inline key fragment", "toml", {
+  "[data]",
+  "is_{{ $r }} = {{ has $r $roles }}",
+}, {
+  "[data]",
+  "is_{{ $r }} = {{ has $r $roles }}",
+}, function(masked)
+  for _, l in ipairs(masked) do
+    if l:match('^is_"') then
+      return "key-position placeholder was quoted: " .. l
+    end
+  end
+end)
+
 -- Pure-function cases -------------------------------------------------------
 
 local function eq(name, got, want)

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -240,6 +240,40 @@ do
   end
 end
 
+-- 10. an action whose closing }} sits inside a quoted string: the scan must skip
+-- the inner }} rather than cutting the span short. chezmoi's own merge config
+-- emits exactly this shape, quoting a template that renders another template.
+run_case("nested quoted braces", "toml", {
+  "[merge]",
+  'args = ["-d", "{{ "{{ .Destination }}" }}", "{{ "{{ .Source }}" }}"]',
+}, {
+  "[merge]",
+  'args = ["-d", "{{ "{{ .Destination }}" }}", "{{ "{{ .Source }}" }}"]',
+})
+
+-- 11. a half-typed action (no closing }}) on a line that has another complete
+-- one: masking must consume to end of line instead of erroring. This is the
+-- state of every line mid-keystroke, so it has to degrade quietly.
+run_case("unterminated trailing action", "toml", {
+  "[d]",
+  "k = {{ .a }} {{ .b",
+}, {
+  "[d]",
+  "k = {{ .a }} {{ .b",
+})
+
+-- 12. a template with no resolvable target language is passed through untouched
+-- rather than formatted as itself
+run_case("gotmpl target passes through", "gotmpl", {
+  "{{- if .x }}",
+  "whatever   spacing",
+  "{{- end }}",
+}, {
+  "{{- if .x }}",
+  "whatever   spacing",
+  "{{- end }}",
+})
+
 -- Pure-function cases -------------------------------------------------------
 
 local function eq(name, got, want)
@@ -249,6 +283,40 @@ local function eq(name, got, want)
   else
     print("ok   " .. name)
   end
+end
+
+-- json targets are formatted as jsonc so the // comment placeholders parse; the
+-- scratch buffer is renamed accordingly even when the target is plain .json
+do
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_name(buf, vim.fs.normalize(vim.fn.tempname()) .. "/settings.json.tmpl")
+  vim.b[buf].chezmoi_target_ft = "json"
+  _G.captured_name = nil
+  local done
+  format.formatter.format(nil, { buf = buf }, { "{", "{{- if .x }}", '  "a": 1', "{{- end }}", "}" }, function()
+    done = true
+  end)
+  vim.wait(5000, function()
+    return done
+  end)
+  eq("json scratch renamed to .jsonc", (_G.captured_name or ""):match("%.jsonc$") ~= nil, true)
+end
+
+-- a json target whose deployed name carries no .json suffix at all (.prettierrc,
+-- .eslintrc) still has to reach the jsonc formatter, so the extension is appended
+do
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_name(buf, vim.fs.normalize(vim.fn.tempname()) .. "/dot_prettierrc.tmpl")
+  vim.b[buf].chezmoi_target_ft = "json"
+  _G.captured_name = nil
+  local done
+  format.formatter.format(nil, { buf = buf }, { "{", "{{- if .x }}", '  "a": 1', "{{- end }}", "}" }, function()
+    done = true
+  end)
+  vim.wait(5000, function()
+    return done
+  end)
+  eq("suffixless json target gains .jsonc", (_G.captured_name or ""):match("prettierrc%.jsonc$") ~= nil, true)
 end
 
 local diagnostics = require("chezmoi-template.diagnostics")

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -189,6 +189,57 @@ run_case("toml inline key fragment", "toml", {
   end
 end)
 
+-- 9. coarse fallback: some lines have no valid token form — a control-flow pair
+-- wrapping content, or a template glued to a bare word. Rather than failing the
+-- whole file, those are re-masked as inert comment placeholders so the rest of
+-- the file still formats and the lines themselves round-trip untouched.
+_G.conform_reject = function(masked)
+  for _, l in ipairs(masked) do
+    if l:match("CHEZMOI_TMPL_%d+_%d+") then -- reject any fine (token) masking
+      return true
+    end
+  end
+end
+run_case("coarse fallback on unmaskable lines", "toml", {
+  "[d]",
+  "{{ if .on }}k = 1{{ end }}",
+  "k = {{ .x }}suffix",
+}, {
+  "[d]",
+  "{{ if .on }}k = 1{{ end }}",
+  "k = {{ .x }}suffix",
+}, function(masked)
+  for i = 2, 3 do
+    if not masked[i]:match("^#%s*CHEZMOI_TMPL_%d+$") then
+      return "line " .. i .. " is not a whole-line comment placeholder: " .. masked[i]
+    end
+  end
+end)
+_G.conform_reject = nil
+
+-- both passes failing still surfaces the error rather than silently mangling
+do
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.b[buf].chezmoi_target_ft = "toml"
+  _G.conform_reject = function()
+    return true
+  end
+  local got_err, done
+  format.formatter.format(nil, { buf = buf }, { "[d]", "k = {{ .x }}" }, function(err)
+    got_err, done = err, true
+  end)
+  vim.wait(5000, function()
+    return done
+  end)
+  _G.conform_reject = nil
+  if not got_err then
+    failures = failures + 1
+    print("FAIL both passes rejected still reports an error")
+  else
+    print("ok   both passes rejected still reports an error")
+  end
+end
+
 -- Pure-function cases -------------------------------------------------------
 
 local function eq(name, got, want)


### PR DESCRIPTION
## What & why

Two defects in how the conform formatter masks Go-template spans before handing
a template to the target filetype's formatter.

### 1. Key-position placeholders were quoted

A placeholder was quoted whenever it was not inside a string literal — but a
template spliced into a **bare key** is not inside a string either, so

```toml
  is_{{ $r }} = {{ has $r $roles }}
```

masked to `is_"CHEZMOI_TMPL_56_1" = "CHEZMOI_TMPL_56_2"`. That splits the
identifier, taplo rejects the whole file, and formatting fails with
`Formatter failed. See :ConformInfo for details`:

```
Formatter 'taplo' error: error: invalid TOML
56 │   is_"CHEZMOI_TMPL_56_1" = "CHEZMOI_TMPL_56_2"
   │      ^^^^^^^^^^^^^^^^^^^ expected "="
```

The module header already described the intended rule, but the implementation
only tested the string case. The distinction is not "does the token have a
neighbour" — it is "is a bare word legal in this position". Identifier
characters glue the token into a key or word, so it must stay bare; punctuation
neighbours (`[`, `,`, `=`) leave it standalone in value position, where TOML and
JSON still require quotes. A placeholder adjacent to `[%w_%-%.]` on either side
is therefore left bare, and `is_{{ $r }}` masks to the valid bare key
`is_CHEZMOI_TMPL_56_1` while the value keeps its quotes.

### 2. Lines with no valid token form failed the entire file

Some lines cannot be expressed as an inline placeholder in the target syntax at
all:

| line | why no token works |
| --- | --- |
| `k = {{ .x }}suffix` | bare is a bare word in value position, quoted splits the word — both invalid |
| `{{ if .on }}k = 1{{ end }}` | control flow is structure, not a value; the whole-line-directive branch only fires when the line is *nothing but* directives |

Either one made the masked buffer unparseable, so nothing in the file was
formatted. A rejected mask is now retried with every template-bearing line
replaced by a comment placeholder, which is inert in any syntax: those lines
come back untouched and everything else formats. Given

```toml
[d]
a="unaligned"
{{ if .on }}k = 1{{ end }}
c=3
```

the result is now

```toml
[d]
  a = "unaligned"
  {{ if .on }}k = 1{{ end }}
  c = 3
```

where previously the file was returned unchanged with a formatter error.

The fine token mask remains the first attempt, so lines that can be laid out
still are, and the second pass costs a spawn only when the first is rejected.
When both passes are rejected the error still surfaces, so a genuine syntax
error is not silently swallowed.

## Checklist

- [x] `make test` passes — 3 new cases: the bare-key mask, the coarse fallback, and both-passes-rejected still erroring
- [x] `make smoke` passes (if `resolve.lua` / `inject.lua` / `encryption.lua` changed)
- [x] README / `doc/chezmoi-template.txt` updated (if config surface or commands changed)
- [x] AI assistance disclosed (if any) — see [CONTRIBUTING](CONTRIBUTING.md)

Drafted with AI assistance (Claude Code). `make test`, `make smoke` and
`stylua --check` run locally. Both rules were also measured against a 26-case
probe covering TOML, JSON, YAML and shell templates — table headers, dotted
headers, arrays, inline tables, multiline strings, nested quotes, key and value
positions — which goes from 2 masking failures to 0 with no change to the cases
that already worked.