### PR TITLE
fix(activate): bring up the plugin for managed files that are not templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,14 @@ The two annotation lines are optional — with [lazydev.nvim](https://github.com
 
 `lazy = false`, but startup stays cheap: `setup()` only registers filetype
 detection, the treesitter directive, and light triggers — the heavy work (module
-loads, autocmds) is deferred until the first template opens or a `:Chezmoi*`
+loads, autocmds) is deferred until the first managed file opens or a `:Chezmoi*`
 command runs. So it costs ~nothing on sessions where you never touch a chezmoi
-file, whether the plugin loads via `opts` or bare. Keep `lazy = false` — don't
+file, whether the plugin loads via `opts` or bare.
+
+Recognizing a managed file that isn't a template — most of a source directory —
+means knowing where the source directory is, so the first buffer of a session
+resolves it with one `chezmoi source-path`, cached from then on. Set
+`source_dir` to skip even that. Keep `lazy = false` — don't
 set `ft`/`cmd`; the deferral is internal, and filetype detection must register at
 startup for `.tmpl` files to be recognized.
 

--- a/doc/chezmoi-template.txt
+++ b/doc/chezmoi-template.txt
@@ -50,9 +50,14 @@ change options. With lazy.nvim: >lua
 <
 `lazy = false`, but startup stays cheap: only filetype detection and light
 triggers register up front; the heavy setup() is deferred until the first
-template opens or a :Chezmoi* command runs. Don't set ft/cmd — the internal
+managed file opens or a :Chezmoi* command runs. Don't set ft/cmd — the internal
 bootstrap handles lazy-loading, and its filetype registration must run at
 startup.
+
+Managed files that are not templates (most of a source directory) are
+recognized by source-dir membership, so the first buffer of a session resolves
+the source dir with one `chezmoi source-path`, cached from then on. Setting the
+source_dir option skips that lookup.
 
 Without a plugin spec, options can also be set via >lua
 

--- a/lua/chezmoi-template/encryption.lua
+++ b/lua/chezmoi-template/encryption.lua
@@ -105,6 +105,10 @@ function M.setup()
       if not resolve.is_managed(ctx.file) then
         return
       end
+      -- An encrypted file is a managed source file like any other: bring up the
+      -- rest of the plugin (commands, apply-on-save, icons) for it too. Safe
+      -- here because _activate() no longer touches this module's augroup.
+      require("chezmoi-template")._activate()
 
       -- Never persist decrypted content: no swap, no undo history on disk
       vim.bo[ctx.buf].binary = true

--- a/lua/chezmoi-template/init.lua
+++ b/lua/chezmoi-template/init.lua
@@ -156,6 +156,16 @@ function M._register()
   -- touches resolve when a tree is actually parsed.
   require("chezmoi-template.inject").register_directive()
 
+  -- Encryption registers on BufReadPre, and an autocmd created while an event
+  -- is already dispatching does not run for that event — so activating from
+  -- another BufReadPre handler would be too late and the first encrypted file
+  -- of a session would open as ciphertext. Register it up front like the
+  -- treesitter directive; setup() only creates an autocmd, and its callback is
+  -- what does the work.
+  if M.config.encryption.enabled then
+    require("chezmoi-template.encryption").setup()
+  end
+
   local group = vim.api.nvim_create_augroup("chezmoi-template.bootstrap", { clear = true })
   vim.api.nvim_create_autocmd({ "BufReadPre", "BufNewFile" }, {
     group = group,
@@ -175,6 +185,23 @@ function M._register()
     pattern = "gotmpl",
     callback = function()
       M._activate()
+    end,
+  })
+  -- Managed files that are not templates — a plain .lua, a *.age — match none
+  -- of the patterns above, so nothing would activate for them and apply-on-save,
+  -- transparent encryption, redirect and notify-on-open would quietly do
+  -- nothing. Most of a chezmoi source dir is such files, so catch them by
+  -- source-dir membership instead of by name. is_managed resolves the source
+  -- dir once (one `chezmoi source-path`, cached for the session) and is a
+  -- string compare from then on; with no chezmoi it returns false without
+  -- spawning anything.
+  vim.api.nvim_create_autocmd({ "BufReadPre", "BufNewFile" }, {
+    group = group,
+    pattern = "*",
+    callback = function(ev)
+      if ev.file ~= "" and require("chezmoi-template.resolve").is_managed(ev.file) then
+        M._activate()
+      end
     end,
   })
   vim.api.nvim_create_user_command("Chezmoi", function(a)
@@ -208,9 +235,8 @@ function M._activate()
   if M.config.icons.enabled then
     require("chezmoi-template.icons").setup()
   end
-  if M.config.encryption.enabled then
-    require("chezmoi-template.encryption").setup()
-  end
+  -- encryption is registered in _register(); re-running setup() here would clear
+  -- its augroup and drop the buffer-local handlers it just installed.
   require("chezmoi-template.commands").setup()
   if M.config.diagnostics.enabled then
     require("chezmoi-template.diagnostics").setup()

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -285,6 +285,18 @@ local function eq(name, got, want)
   end
 end
 
+-- bootstrap (still pre-activation here): most of a chezmoi source dir is plain
+-- files, not templates, so activation cannot key off *.tmpl alone — a `*`
+-- BufReadPre carries source-dir membership.
+do
+  local pats = {}
+  for _, a in ipairs(vim.api.nvim_get_autocmds({ event = "BufReadPre", group = "chezmoi-template.bootstrap" })) do
+    pats[a.pattern] = true
+  end
+  eq("bootstrap watches every buffer for managed files", pats["*"], true)
+  eq("bootstrap still watches templates by name", pats["*.tmpl"], true)
+end
+
 -- json targets are formatted as jsonc so the // comment placeholders parse; the
 -- scratch buffer is renamed accordingly even when the target is plain .json
 do
@@ -862,6 +874,19 @@ do
   vim.cmd("Chezmoi pick")
   eq("unknown picker backend errors", has_note("unknown picker"), true)
   ct.config.picker = nil
+end
+
+-- _activate must not re-register encryption: its BufReadPre callback installs
+-- buffer-local handlers for the file being read, and clearing the augroup
+-- mid-read would drop them
+do
+  local count = function()
+    return #vim.api.nvim_get_autocmds({ group = "chezmoi-template.encryption" })
+  end
+  local before = count()
+  ct._activated = false
+  ct._activate()
+  eq("activate leaves the encryption augroup intact", count(), before)
 end
 
 -- encryption: decrypt on read, re-encrypt on write, exclude patterns

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -295,6 +295,25 @@ do
   end
   eq("bootstrap watches every buffer for managed files", pats["*"], true)
   eq("bootstrap still watches templates by name", pats["*.tmpl"], true)
+
+  -- and the trigger itself: every buffer is seen, only managed ones activate
+  local cb
+  for _, a in ipairs(vim.api.nvim_get_autocmds({ event = "BufReadPre", group = "chezmoi-template.bootstrap" })) do
+    if a.pattern == "*" then
+      cb = a.callback
+    end
+  end
+  local ct0 = require("chezmoi-template")
+  cb({ file = "/definitely/not/a/chezmoi/source/foo.lua", buf = 0 })
+  eq("managed-file trigger ignores paths outside the source dir", ct0._activated, nil)
+  cb({ file = vim.fs.normalize(vim.fn.getcwd()) .. "/tests/dot_zshrc.tmpl", buf = 0 })
+  eq("managed-file trigger activates on a managed file", ct0._activated, true)
+
+  -- put the bootstrap triggers back: activating deleted their augroup, and the
+  -- rest of the file expects the plugin to still be waiting for a template
+  ct0._activated = nil
+  ct0._registered = false
+  ct0._register()
 end
 
 -- json targets are formatted as jsonc so the // comment placeholders parse; the
@@ -1152,6 +1171,19 @@ do
   require("chezmoi-template.inject").seed_buffer(yb, SRC .. "/dot_included.json.tmpl")
   eq("non-excluded still seeds target ft", vim.b[yb].chezmoi_target_ft, "json")
   ct.config.inject.exclude = {}
+end
+
+-- _register wires encryption up front when it is enabled, rather than leaving it
+-- to _activate: an autocmd created while BufReadPre is already dispatching does
+-- not run for that read, so the first encrypted file of a session would open as
+-- ciphertext. Last in the file — it re-runs registration.
+do
+  pcall(vim.api.nvim_del_augroup_by_name, "chezmoi-template.encryption")
+  ct.config.encryption.enabled = true
+  ct._registered = false
+  ct._register()
+  local ok, autocmds = pcall(vim.api.nvim_get_autocmds, { group = "chezmoi-template.encryption" })
+  eq("_register wires encryption when enabled", ok and #autocmds > 0, true)
 end
 
 -- flush coverage stats before exit (`nvim -l` may skip luacov's exit hook)


### PR DESCRIPTION
## What & why

Activation keyed off template names only — `*.tmpl`, `.chezmoiignore*`,
`.chezmoiremove*`, `.chezmoiexternal*`, filetype `gotmpl`, or a `:Chezmoi`
command. Most of a chezmoi source directory is none of those: a plain `.lua`
config, a `*.age`. Opening one never activated the plugin, so **writing it did
nothing at all** — and reported nothing either, because the autocmd that would
have applied it was never registered:

```
$ nvim dot_config/nvim/lua/exact_plugins/nvim-lspconfig.lua   # fresh session
commands module loaded        = false
chezmoi BufWritePost autocmds = 0
# :w -> silence; `chezmoi status` still shows the target modified
```

Transparent encryption had the same hole, with a worse symptom — a fresh
session opening a managed encrypted file showed the raw ciphertext:

```
first line = -----BEGIN AGE ENCRYPTED FILE-----
```

Editing that buffer and writing would have overwritten the source with mangled
ciphertext. `redirect` and `notify_on_open` were equally inert. The features
appeared to work only because opening any template first armed them for the
rest of the session.

## Changes

Activation now also keys off **source-dir membership**: a `*` BufReadPre /
BufNewFile that consults `is_managed`. That resolves the source dir once per
session (one `chezmoi source-path`, cached from then on; none at all when
`source_dir` is configured or `chezmoi` is absent) and is a string compare
afterwards.

Encryption cannot be started that way. It registers on `BufReadPre` itself, and
an autocmd created while an event is already dispatching does not run for that
event — so activating from another `BufReadPre` handler is too late and the
first encrypted file of a session still opens as ciphertext (verified). It is
registered in `_register()` instead, alongside the treesitter directive, which
the module docs already carve out as the same kind of exception: registration is
one autocmd, the callback does the work.

It is correspondingly removed from `_activate()`. Re-running `encryption.setup()`
clears its augroup, which would drop the buffer-local `BufReadPost` /
`BufWriteCmd` handlers it installs for the file being read — a test pins that.

## Cost

One `chezmoi source-path` on the first buffer of a session, where previously
there was none until a template was opened. The README and `doc/` claims about
cheap startup are updated to say so rather than quietly become untrue, and point
at `source_dir` for anyone who wants to avoid even that.

## Checklist

- [x] `make test` passes — the `*` bootstrap trigger, and that activate leaves the encryption augroup intact
- [x] `make smoke` passes (if `resolve.lua` / `inject.lua` / `encryption.lua` changed)
- [x] README / `doc/chezmoi-template.txt` updated (if config surface or commands changed)
- [x] AI assistance disclosed (if any) — see [CONTRIBUTING](CONTRIBUTING.md)

Drafted with AI assistance (Claude Code). `make test`, `make smoke` and
`stylua --check` run locally, plus end-to-end checks against a real chezmoi
source directory in fresh sessions: a plain managed `.lua` now activates,
applies and notifies; a managed `.age` decrypts and gets its target filetype; an
`encryption.exclude` match still opens armored.