### PR TITLE
fix(matchup): match else-with openers and full else chains

### DIFF
--- a/after/queries/gotmpl/matchup.scm
+++ b/after/queries/gotmpl/matchup.scm
@@ -1,13 +1,12 @@
 ; vim-matchup tree-sitter queries for Go templates (gotmpl)
 ; Format: @open / @mid.<group>.<n> / @close + @scope.<group>
 ; {{ if }} … {{ else if }} … {{ else }} … {{ end }}
-; Anchor (`.`) pins @open to the FIRST `if` only; the `if` inside `{{ else if }}`
-; follows `else` (not a delimiter), so it is correctly skipped.
+; The grammar inlines else / else-if clauses, so their `else` and `if` tokens
+; are direct children of if_action. The anchor (`.`) pins @open to the FIRST
+; `if` only; every later `else` or `if` belongs to an else / else-if clause
+; and is a mid. `*` (not `?`) because chains can hold any number of them.
 ; Both `{{` and the whitespace-trim marker `{{-` are distinct grammar tokens —
 ; chezmoi templates use `{{-`, so the alternation must list both.
-; `else` is `?` (optional): a plain `{{ if }}…{{ end }}` has no `else`, and an
-; un-quantified token would make the whole pattern require one, so it would fail
-; to match (and matchup would fall back to brace matching).
 (if_action
   [
     "{{"
@@ -15,10 +14,16 @@
   ]
   .
   "if" @open.if
-  "else"? @mid.if.1
+  [
+    "else"
+    "if"
+  ]* @mid.if.1
   "end" @close.if) @scope.if
 
 ; {{ range }} … {{ else }} … {{ end }}  (+ continue/break as inner mids)
+; range takes at most one `else` (no else-if form), so `?` is enough; an
+; un-quantified token would make the whole pattern require one and fail to
+; match a plain {{ range }}…{{ end }}.
 (range_action
   "range" @open.range
   "else"? @mid.range.1
@@ -30,10 +35,20 @@
 (break_action
   "break" @mid.range.3)
 
-; {{ with }} … {{ else }} … {{ end }}
+; {{ with }} … {{ else with }} … {{ else }} … {{ end }}
+; Same shape as if: anchored opener (an else-with clause's `with` is a direct
+; child too and must not open), `*` mids for else / else-with chains.
 (with_action
+  [
+    "{{"
+    "{{-"
+  ]
+  .
   "with" @open.with
-  "else"? @mid.with.1
+  [
+    "else"
+    "with"
+  ]* @mid.with.1
   "end" @close.with) @scope.with
 
 ; {{ block }} … {{ end }}


### PR DESCRIPTION
The with pattern captured every direct-child `with` token as an opener, so the `with` in `{{ else with }}` opened a phantom scope. The grammar inlines else clauses, which puts their tokens directly under `with_action`; the pattern now anchors the opener to the delimiter, the same way the if pattern already does.

The else mids used `?`, which stops at one else, but if and with chains can hold any number of `{{ else if }}` / `{{ else with }}` clauses. They are now quantified with `*` and include the clause keyword, so each clause spans one mid delimiter and `%` works with the cursor on either word.

Verified headless against tree-sitter-go-template: chains of else-if / else-with, trim markers, nested actions, range with continue/break, block and define all produce the expected open/mid/close sets after vim-matchup's span-merge and range dedup. Mirrored verbatim to vim-matchup PR andymass/vim-matchup#446.