### PR TITLE
fix(encryption): read the enabled flag at dispatch, not at registration

### DIFF
--- a/lua/chezmoi-template/encryption.lua
+++ b/lua/chezmoi-template/encryption.lua
@@ -92,6 +92,14 @@ function M.setup()
     -- .age (age/rage) and .asc (gpg) — chezmoi's encryption suffixes
     pattern = { "*.age", "*.asc" },
     callback = function(ctx)
+      -- Read `enabled` here, not at registration: setup() runs twice under
+      -- lazy.nvim (the plugin/ bootstrap with defaults, then the opts merge),
+      -- so gating registration on the first call left encryption dead whenever
+      -- opts were what turned it on. Every other option is read at dispatch
+      -- time for the same reason.
+      if not cfg().enabled then
+        return
+      end
       -- Excluded paths (e.g. passphrase-encrypted bootstrap keys) and files
       -- outside the source dir open as plain binary. Match the normalized
       -- (forward-slash) path so patterns are portable — a raw autocmd path is

--- a/lua/chezmoi-template/init.lua
+++ b/lua/chezmoi-template/init.lua
@@ -161,10 +161,11 @@ function M._register()
   -- another BufReadPre handler would be too late and the first encrypted file
   -- of a session would open as ciphertext. Register it up front like the
   -- treesitter directive; setup() only creates an autocmd, and its callback is
-  -- what does the work.
-  if M.config.encryption.enabled then
-    require("chezmoi-template.encryption").setup()
-  end
+  -- what does the work. Unconditional: _register() runs once, but setup() may
+  -- run twice (the plugin/ bootstrap, then a lazy.nvim opts merge), and the
+  -- second call is usually the one enabling encryption — so the callback reads
+  -- config.encryption.enabled itself rather than this deciding for it.
+  require("chezmoi-template.encryption").setup()
 
   local group = vim.api.nvim_create_augroup("chezmoi-template.bootstrap", { clear = true })
   vim.api.nvim_create_autocmd({ "BufReadPre", "BufNewFile" }, {

--- a/plugin/chezmoi-template.lua
+++ b/plugin/chezmoi-template.lua
@@ -1,7 +1,8 @@
 -- Zero-config bootstrap: works without a setup() call. setup() is cheap — it
 -- registers filetype detection, the treesitter directive, and light triggers,
 -- deferring the heavy work until the first template opens or a :Chezmoi* command
--- runs. A later explicit setup({...}) (e.g. lazy.nvim `opts`) re-merges and wins.
+-- runs. A later explicit setup({...}) (e.g. lazy.nvim `opts`) re-merges and wins:
+-- options are read where they are used, not latched by this first registration.
 if vim.g.loaded_chezmoi_template then
   return
 end

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1388,6 +1388,19 @@ do
   ct._register()
   local ok, autocmds = pcall(vim.api.nvim_get_autocmds, { group = "chezmoi-template.encryption" })
   eq("_register wires encryption regardless of the flag", ok and #autocmds > 0, true)
+
+  -- and with the flag off that registration stays inert: the callback bails
+  -- before touching the buffer, so a managed *.age opens as the raw bytes on disk
+  local off = SRC .. "/enc_disabled.age"
+  local f = assert(io.open(off, "wb"))
+  f:write("CIPHERTEXT")
+  f:close()
+  fake["decrypt"] = { code = 0, stdout = "must not appear\n" }
+  vim.cmd.edit(vim.fn.fnameescape(off))
+  local ob = vim.api.nvim_get_current_buf()
+  eq("*.age opens raw while encryption is disabled", vim.api.nvim_buf_get_lines(ob, 0, -1, false), { "CIPHERTEXT" })
+  vim.api.nvim_buf_delete(ob, { force = true })
+  os.remove(off)
 end
 
 -- flush coverage stats before exit (`nvim -l` may skip luacov's exit hook)

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1106,6 +1106,43 @@ do
   os.remove(skip)
 end
 
+-- encryption must survive the two-call setup order: the plugin/ bootstrap runs
+-- setup({}) with encryption off, then lazy.nvim merges `opts` and turns it on.
+-- _register() only runs once, so deciding there left the augroup missing and
+-- every *.age file opening as ciphertext.
+do
+  local armed = function()
+    local ok, aus = pcall(vim.api.nvim_get_autocmds, { group = "chezmoi-template.encryption" })
+    return ok and #aus > 0
+  end
+  ct.config.encryption.enabled = false
+  ct._registered = nil
+  pcall(vim.api.nvim_del_augroup_by_name, "chezmoi-template.encryption")
+
+  ct.setup({}) -- plugin/chezmoi-template.lua bootstrap: defaults, encryption off
+  ct.setup({ encryption = { enabled = true } }) -- lazy.nvim opts merge
+  eq("setup after registration still arms encryption", armed(), true)
+
+  local age = SRC .. "/enc_late_arm.age"
+  local f = assert(io.open(age, "wb"))
+  f:write("CIPHERTEXT")
+  f:close()
+  fake["decrypt"] = { code = 0, stdout = "armed late\n" }
+  vim.cmd.edit(vim.fn.fnameescape(age))
+  local lb = vim.api.nvim_get_current_buf()
+  eq("*.age decrypts when opts enabled it", vim.api.nvim_buf_get_lines(lb, 0, -1, false), { "armed late" })
+  vim.api.nvim_buf_delete(lb, { force = true })
+  os.remove(age)
+
+  -- the re-run of _register() recreated what _activate() had torn down: the
+  -- bootstrap triggers and the lazy :Chezmoi stub (which delegates back to
+  -- :Chezmoi and only terminates because _activate() swaps in the real command
+  -- — already activated here, so it would recurse). Restore the activated state
+  -- for the later cases.
+  pcall(vim.api.nvim_del_augroup_by_name, "chezmoi-template.bootstrap")
+  require("chezmoi-template.commands").setup()
+end
+
 -- inject autocmds: BufReadPre seeds real *.tmpl reads; .chezmoitemplates/
 -- partials get forced to gotmpl on BufReadPost
 do
@@ -1338,17 +1375,19 @@ do
   ct.config.inject.exclude = {}
 end
 
--- _register wires encryption up front when it is enabled, rather than leaving it
--- to _activate: an autocmd created while BufReadPre is already dispatching does
--- not run for that read, so the first encrypted file of a session would open as
--- ciphertext. Last in the file — it re-runs registration.
+-- _register wires encryption up front rather than leaving it to _activate: an
+-- autocmd created while BufReadPre is already dispatching does not run for that
+-- read, so the first encrypted file of a session would open as ciphertext. It
+-- registers even with encryption off, because _register runs once while setup()
+-- may run twice and the second call is what usually enables it — the callback
+-- reads the flag itself. Last in the file — it re-runs registration.
 do
   pcall(vim.api.nvim_del_augroup_by_name, "chezmoi-template.encryption")
-  ct.config.encryption.enabled = true
+  ct.config.encryption.enabled = false
   ct._registered = false
   ct._register()
   local ok, autocmds = pcall(vim.api.nvim_get_autocmds, { group = "chezmoi-template.encryption" })
-  eq("_register wires encryption when enabled", ok and #autocmds > 0, true)
+  eq("_register wires encryption regardless of the flag", ok and #autocmds > 0, true)
 end
 
 -- flush coverage stats before exit (`nvim -l` may skip luacov's exit hook)


### PR DESCRIPTION
Transparent decryption never engaged when `encryption.enabled` was set through a plugin spec's `opts`. Managed `*.age` files opened as ciphertext, with no error and no notification.

`encryption.setup()` was called from `_register()` behind an `if config.encryption.enabled` check, and `_register()` runs once. Plugin managers source `plugin/` before applying `opts`, so the zero-config bootstrap `setup({})` ran first with encryption still off, skipped the wiring, and latched `_registered`. The later `setup(opts)` merged `encryption.enabled = true` correctly but returned early at the latch, so the `BufReadPre` autocmd was never created. Setting the option through `vim.g.chezmoi_template`, or through an explicit `setup()` call that is the only one, was unaffected.

Registration is now unconditional and the callback reads `config.encryption.enabled` itself. That matches how `redirect`, `apply.on_save` and `notify_on_open` already work, and it removes the ordering dependency rather than patching the one sequence that exposed it. Registering up front still matters for the original reason: an autocmd created while `BufReadPre` is dispatching does not run for that read, so the first encrypted file of a session would otherwise open as ciphertext.

The comment in `plugin/chezmoi-template.lua` claiming a later `setup({...})` wins was true of the config table but not of this registration, and has been corrected.

## Tests

The suite missed this because it called `encryption.setup()` directly instead of going through `setup()`, leaving the registration path untested. Two cases cover it now:

- the two-call order, `setup({})` followed by `setup({ encryption = { enabled = true } })`, then a `*.age` buffer that must decrypt
- `_register()` wiring encryption even with the flag off, which is the invariant the callback check depends on

Both fail on the previous code. `make test` and `stylua --check lua plugin tests` pass.
