### PR TITLE
feat(picker)!: decrypted previews; exclude patterns stack on the defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ require("chezmoi-template").setup({
   picker = {
     backend = nil,             -- "snacks"|"telescope"|"fzf-lua"|"mini"|"select"; nil = auto
     display = "target",        -- entry labels: "target" (.zshrc) or "source" (dot_zshrc.tmpl)
-    exclude = nil,             -- lua patterns to hide; nil = built-in internals list, {} = show all
+    exclude = {},              -- lua patterns hidden on top of the internals list; false = show all
   },
   encryption = {
     enabled = false,           -- opt-in; delegates to chezmoi decrypt/encrypt
@@ -235,8 +235,8 @@ The source only activates in gotmpl buffers. Inside `{{ … }}` it narrows by cu
 `:Chezmoi pick` opens a file picker over the source directory. Entries are built by the plugin (via `git ls-files`, so the source repo's `.gitignore` is respected; plain fs walk for non-git source dirs), identically across backends:
 
 - **Labels** show the deployed target name (`dot_zshrc.tmpl` → `.zshrc`); set `picker.display = "source"` for raw source names.
-- **Chezmoi internals are hidden** by default (`.git/`, `.chezmoi.$FORMAT.tmpl`, `.chezmoiversion`, `.chezmoiroot`, `.chezmoidata.*`) while editable specials stay listed (`.chezmoiignore`, `.chezmoiscripts/`, `.chezmoitemplates/`, `.chezmoiexternal.*`). `picker.exclude` takes your own lua patterns (matched against the source-relative path) and replaces the built-in list; `{}` shows everything.
-- **Preview highlights the target language** inside the template, same as opening the file.
+- **Chezmoi internals are hidden** by default (`.git/`, `.chezmoi.$FORMAT.tmpl`, `.chezmoiversion`, `.chezmoiroot`, `.chezmoidata.*`) while editable specials stay listed (`.chezmoiignore`, `.chezmoiscripts/`, `.chezmoitemplates/`, `.chezmoiexternal.*`). `picker.exclude` hides your own lua patterns (matched against the source-relative path) on top of that list — e.g. `exclude = { "^private_dot_ssh/.*id_" }` keeps ssh keys out of the picker while `.ssh/config` stays. `exclude = false` shows everything.
+- **Preview highlights the target language** inside the template, same as opening the file. Managed encrypted files (`*.age`, `*.asc`) preview decrypted when `encryption.enabled` is on, typed as their deployed target.
 
 Backend auto-detects among loaded pickers (snacks → telescope → fzf-lua → mini.pick) with a `vim.ui.select` fallback; if your picker is lazy-loaded it may not be detected — set `picker.backend = "telescope"` (etc.) explicitly (a plain string `picker = "telescope"` still works as shorthand). Map it however you like:
 

--- a/lua/chezmoi-template/encryption.lua
+++ b/lua/chezmoi-template/encryption.lua
@@ -36,6 +36,41 @@ local function encrypt(text, file)
   return ret
 end
 
+-- A file the transparent layer handles: encryption on, an encrypted suffix,
+-- not excluded, inside the source dir. Read per call, not at registration:
+-- setup() can run twice (the plugin/ bootstrap with defaults, then a lazy.nvim
+-- opts merge), and the second call is usually the one enabling encryption.
+-- Excludes (e.g. passphrase-encrypted bootstrap keys) match the normalized
+-- (forward-slash) path so patterns are portable — a raw autocmd path is
+-- backslashed on Windows and would dodge "/"-style patterns.
+local function eligible(file)
+  if not cfg().enabled then
+    return false
+  end
+  local nfile = vim.fs.normalize(file)
+  if not (nfile:match("%.age$") or nfile:match("%.asc$")) then
+    return false
+  end
+  for _, pat in ipairs(cfg().exclude) do
+    if nfile:match(pat) then
+      return false
+    end
+  end
+  return resolve.is_managed(file)
+end
+
+-- Decrypted text of a managed encrypted file, or nil (encryption off, not an
+-- encrypted managed file, excluded, or decryption failed). For read-only
+-- consumers like the picker preview; buffers editing the file go through the
+-- autocmds below instead.
+function M.text(file)
+  if not eligible(file) then
+    return nil
+  end
+  local ret = decrypt(file)
+  return ret.code == 0 and ret.stdout or nil
+end
+
 local function read_post(args)
   local ret = decrypt(args.file)
   if ret.code ~= 0 then
@@ -92,25 +127,8 @@ function M.setup()
     -- .age (age/rage) and .asc (gpg) — chezmoi's encryption suffixes
     pattern = { "*.age", "*.asc" },
     callback = function(ctx)
-      -- Read `enabled` here, not at registration: setup() runs twice under
-      -- lazy.nvim (the plugin/ bootstrap with defaults, then the opts merge),
-      -- so gating registration on the first call left encryption dead whenever
-      -- opts were what turned it on. Every other option is read at dispatch
-      -- time for the same reason.
-      if not cfg().enabled then
-        return
-      end
-      -- Excluded paths (e.g. passphrase-encrypted bootstrap keys) and files
-      -- outside the source dir open as plain binary. Match the normalized
-      -- (forward-slash) path so patterns are portable — a raw autocmd path is
-      -- backslashed on Windows and would dodge "/"-style patterns.
-      local nfile = vim.fs.normalize(ctx.file)
-      for _, pat in ipairs(cfg().exclude) do
-        if nfile:match(pat) then
-          return
-        end
-      end
-      if not resolve.is_managed(ctx.file) then
+      -- Disabled, excluded, and unmanaged files open as plain binary
+      if not eligible(ctx.file) then
         return
       end
       -- An encrypted file is a managed source file like any other: bring up the

--- a/lua/chezmoi-template/init.lua
+++ b/lua/chezmoi-template/init.lua
@@ -36,7 +36,7 @@ local M = {}
 ---@class chezmoi-template.Config.picker
 ---@field backend? "snacks"|"telescope"|"fzf-lua"|"mini"|"select" nil = auto-detect among loaded pickers
 ---@field display? "target"|"source" entry labels: deployed names (.zshrc) or raw source names (dot_zshrc.tmpl)
----@field exclude? string[] lua patterns (vs the source-relative path) to hide; nil = built-in internals list, {} = show all
+---@field exclude? string[]|false lua patterns (vs the source-relative path) hidden on top of the built-in internals list; false = show everything
 
 ---@class chezmoi-template.Config.encryption
 ---@field enabled? boolean transparent decrypt/encrypt of chezmoi-managed encrypted files (*.age, *.asc)
@@ -103,10 +103,10 @@ M.config = {
     -- entry labels: "target" = deployed names (dot_zshrc.tmpl -> .zshrc),
     -- "source" = raw source-relative names
     display = "target",
-    -- lua patterns (vs the source-relative path) to hide; nil = built-in
+    -- lua patterns (vs the source-relative path) hidden on top of the built-in
     -- internals list (picker.DEFAULT_EXCLUDE: .git/, .chezmoi.$FORMAT.tmpl,
-    -- .chezmoiversion, .chezmoiroot, .chezmoidata.*), {} = show everything
-    exclude = nil,
+    -- .chezmoiversion, .chezmoiroot, .chezmoidata.*); false = show everything
+    exclude = {},
   },
   -- transparent decrypt/encrypt of chezmoi-managed encrypted files (*.age, *.asc)
   -- via `chezmoi decrypt` / `chezmoi encrypt` (age/rage/builtin/gpg, identities,

--- a/lua/chezmoi-template/picker.lua
+++ b/lua/chezmoi-template/picker.lua
@@ -16,8 +16,8 @@ local resolve = require("chezmoi-template.resolve")
 
 -- Hidden by default: never-edited chezmoi internals. Deliberately keeps
 -- .chezmoiignore, .chezmoiscripts/, .chezmoitemplates/ and .chezmoiexternal*
--- (all editable with target-language support). config.picker.exclude = {}
--- shows everything; a non-nil list replaces this one.
+-- (all editable with target-language support). config.picker.exclude patterns
+-- are hidden on top of this list; exclude = false shows everything.
 M.DEFAULT_EXCLUDE = {
   "^%.git/",
   "^%.chezmoi%.%w+%.tmpl$", -- .chezmoi.toml.tmpl / .chezmoi.yaml.tmpl config template
@@ -29,16 +29,24 @@ M.DEFAULT_EXCLUDE = {
 -- Normalized picker config: a plain string is shorthand for { backend = str }
 -- (pre-1.2 config shape); missing fields get defaults. Normalization lives
 -- here, not in the setup() merge — tbl_deep_extend can't merge string→table.
+-- exclude: user patterns extend the internals defaults instead of replacing
+-- them — nobody hiding their ssh keys wants .git/ back as the price — and
+-- exclude = false is the show-everything escape hatch.
 local function conf()
   local c = require("chezmoi-template").config.picker
   if type(c) == "string" then
     c = { backend = c }
   end
   c = c or {}
+  local exclude = {}
+  if c.exclude ~= false then
+    vim.list_extend(exclude, M.DEFAULT_EXCLUDE)
+    vim.list_extend(exclude, c.exclude or {})
+  end
   return {
     backend = c.backend,
     display = c.display or "target",
-    exclude = c.exclude or M.DEFAULT_EXCLUDE,
+    exclude = exclude,
   }
 end
 
@@ -127,6 +135,40 @@ local function seed_preview(buf, abs)
 end
 M._seed_preview = seed_preview
 
+-- Preview buffers read the file's raw bytes (no BufReadPre fires for them), so
+-- a managed encrypted entry would preview as age/gpg armor. Swap in the
+-- decrypted text and the target filetype instead, mirroring the transparent
+-- decrypt-on-read. Decrypted once per file per picker session — every cursor
+-- move re-previews and each decrypt is a chezmoi spawn.
+local decrypt_cache = {}
+
+local function preview_decrypted(buf, abs)
+  local text = decrypt_cache[abs]
+  if text == nil then
+    text = require("chezmoi-template.encryption").text(abs) or false
+    decrypt_cache[abs] = text
+  end
+  if not text then
+    return false
+  end
+  local lines = vim.split(text, "\n")
+  if lines[#lines] == "" then
+    table.remove(lines)
+  end
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  -- same filetype routing as the real decrypt-on-read (encryption.read_post):
+  -- the deployed name picks the filetype, *.tmpl.age routes through gotmpl
+  local target = resolve.target_path(abs)
+  local ft = target and vim.filetype.match({ filename = target, buf = buf }) or nil
+  if ft then
+    resolve.seed(buf, ft)
+    vim.bo[buf].filetype = abs:match("%.tmpl") and "gotmpl" or ft
+  end
+  return true
+end
+M._preview_decrypted = preview_decrypted
+
 local function edit(abs)
   vim.cmd.edit(vim.fn.fnameescape(abs))
 end
@@ -158,6 +200,8 @@ local backends = {
           if ctx.buf ~= buf then
             seed_preview(ctx.buf, ctx.item.file)
           end
+          -- after the stock previewer: it loaded the raw bytes, overwrite them
+          preview_decrypted(ctx.buf, ctx.item.file)
           return ret
         end,
         -- default confirm jumps to item.file
@@ -192,6 +236,9 @@ local backends = {
               -- maker reads + highlights async, so the synchronous seed
               -- lands before its treesitter start
               seed_preview(self.state.bufnr, entry.value.abs)
+              if preview_decrypted(self.state.bufnr, entry.value.abs) then
+                return
+              end
               tconf.buffer_previewer_maker(entry.value.abs, self.state.bufnr, { bufname = self.state.bufname })
             end,
           }),
@@ -226,6 +273,7 @@ local backends = {
         -- treesitter so injection picks the vars up
         if self.preview_bufnr and vim.api.nvim_buf_is_valid(self.preview_bufnr) then
           seed_preview(self.preview_bufnr, entry.path)
+          preview_decrypted(self.preview_bufnr, entry.path)
         end
       end
       fzf.fzf_exec(lines, {
@@ -256,6 +304,9 @@ local backends = {
           end, entries),
           preview = function(buf_id, item)
             seed_preview(buf_id, item.path)
+            if preview_decrypted(buf_id, item.path) then
+              return
+            end
             MiniPick.default_preview(buf_id, item)
           end,
           -- default choose opens item.path
@@ -291,6 +342,7 @@ function M.open()
     return notify("source directory not found", vim.log.levels.ERROR)
   end
   local c = conf()
+  decrypt_cache = {} -- fresh per session: the source may have been re-encrypted
   local entries = M.build(M.walk(src), src, c)
   if #entries == 0 then
     return notify("no source files to pick", vim.log.levels.WARN)

--- a/lua/chezmoi-template/picker.lua
+++ b/lua/chezmoi-template/picker.lua
@@ -186,7 +186,17 @@ local backends = {
           return { text = e.display, file = e.abs }
         end, entries),
         format = function(item)
-          local icon, hl = Snacks.util.icon(vim.fs.basename(item.text), "file")
+          -- A bare basename loses the path context filetype detection needs
+          -- (.ssh/config, git/config both hit vim.filetype's path patterns), so
+          -- resolve the source path to its deploy target the way open buffers
+          -- do; plain files fall back to the name lookup as before.
+          local icon, hl
+          if require("chezmoi-template").config.icons.enabled then
+            icon, hl = require("chezmoi-template.icons").get(item.file)
+          end
+          if not icon then
+            icon, hl = Snacks.util.icon(vim.fs.basename(item.text), "file")
+          end
           return { { icon .. " ", hl }, { item.text } }
         end,
         preview = function(ctx)

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1186,6 +1186,11 @@ do
           picked.snacks = o
         end,
       },
+      util = {
+        icon = function(name)
+          return "N:" .. name, "NameHl"
+        end,
+      },
     }
   end
   package.preload["telescope.pickers"] = function()
@@ -1259,6 +1264,13 @@ do
   vim.cmd("Chezmoi pick")
   local sitem = by_display(picked.snacks.items, "text")
   eq("snacks gets display text + abs file", { sitem.text, sitem.file }, { ".pick_me", pick_me })
+  -- entry icons resolve the source path to its deploy target (mini.icons fake
+  -- echoes the name it was asked for), so path-context filetypes (.ssh/config,
+  -- git/config) get their real icon; plain files fall back to the name lookup
+  local chunk = picked.snacks.format(sitem)[1][1]
+  eq("snacks icon resolves to the deploy target", chunk, SRC .. "/.pick_me ")
+  local plain = picked.snacks.format({ text = "run.lua", file = SRC .. "/run.lua" })[1][1]
+  eq("snacks icon falls back for plain files", plain, "N:run.lua ")
 
   ct.config.picker = "telescope"
   vim.cmd("Chezmoi pick")

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1230,10 +1230,13 @@ do
     return {
       buffer_or_file = {
         extend = function()
-          return { super = {} }
+          return { super = { new = function() end, preview_buf_post = function() end } }
         end,
       },
     }
+  end
+  package.preload["snacks.picker.preview"] = function()
+    return { file = function() end }
   end
   package.preload["mini.pick"] = function()
     return {
@@ -1278,12 +1281,113 @@ do
   local mitem = by_display(picked.mini.source.items, "text")
   eq("mini gets display text + abs path", { mitem.text, mitem.path }, { ".pick_me", pick_me })
 
+  -- exclude semantics: user patterns stack on the internals defaults instead
+  -- of replacing them; exclude = false lifts every filter
+  local rootf = SRC .. "/.chezmoiroot"
+  local rff = assert(io.open(rootf, "w"))
+  rff:write("x")
+  rff:close()
+  local function displays()
+    local out = {}
+    for _, it in ipairs(picked.snacks.items) do
+      out[it.text] = true
+    end
+    return out
+  end
+  ct.config.picker = { backend = "snacks", exclude = { "pick_me" } }
+  vim.cmd("Chezmoi pick")
+  local shown = displays()
+  eq("user exclude hides its pattern", shown[".pick_me"], nil)
+  eq("internals defaults still apply alongside it", shown[".chezmoiroot"], nil)
+  ct.config.picker = { backend = "snacks", exclude = false }
+  vim.cmd("Chezmoi pick")
+  shown = displays()
+  eq("exclude = false shows everything", { shown[".pick_me"], shown[".chezmoiroot"] }, { true, true })
+  os.remove(rootf)
+
+  -- decrypted preview: every backend's previewer swaps the raw age/gpg armor
+  -- for `chezmoi decrypt` output, typed as the deployed target (gotmpl for
+  -- *.tmpl.age), decrypting each file once per picker session
+  local enc_pick = SRC .. "/enc_pick.tmpl.age"
+  local ef = assert(io.open(enc_pick, "wb"))
+  ef:write("CIPHERTEXT")
+  ef:close()
+  fake["decrypt"] = { code = 0, stdout = "secret {{ .x }}\n" }
+  fake["managed"] = { code = 0, stdout = enc_pick .. "\n" }
+  resolve.invalidate()
+  local d0 = spawns["decrypt"] or 0
+
+  ct.config.picker = "snacks"
+  vim.cmd("Chezmoi pick")
+  local pv1 = vim.api.nvim_create_buf(false, true)
+  picked.snacks.preview({ buf = pv1, item = { file = enc_pick } })
+  eq("snacks preview decrypts", vim.api.nvim_buf_get_lines(pv1, 0, -1, false), { "secret {{ .x }}" })
+  eq("tmpl.age preview typed gotmpl", vim.bo[pv1].filetype, "gotmpl")
+  eq("decrypted preview seeds target ft", vim.b[pv1].chezmoi_target_ft, "zsh")
+  picked.snacks.preview({ buf = pv1, item = { file = enc_pick } })
+  eq("preview decrypts once per session", spawns["decrypt"], d0 + 1)
+
+  ct.config.picker = "telescope"
+  vim.cmd("Chezmoi pick")
+  local eentry, pentry
+  for _, e in ipairs(picked.telescope.finder.results) do
+    if e.abs == enc_pick then
+      eentry = picked.telescope.finder.entry_maker(e)
+    elseif e.abs == pick_me then
+      pentry = picked.telescope.finder.entry_maker(e)
+    end
+  end
+  local pv2 = vim.api.nvim_create_buf(false, true)
+  picked.telescope.previewer.define_preview({ state = { bufnr = pv2 } }, eentry)
+  eq("telescope preview decrypts", vim.api.nvim_buf_get_lines(pv2, 0, -1, false), { "secret {{ .x }}" })
+  -- a plain entry falls through to telescope's own maker
+  local made = false
+  require("telescope.config").values.buffer_previewer_maker = function()
+    made = true
+  end
+  picked.telescope.previewer.define_preview({ state = { bufnr = pv2 } }, pentry)
+  eq("plain entry falls through to the maker", made, true)
+
+  ct.config.picker = "fzf-lua"
+  vim.cmd("Chezmoi pick")
+  local pv3 = vim.api.nvim_create_buf(false, true)
+  picked.fzf.opts.previewer.preview_buf_post({ preview_bufnr = pv3 }, { path = enc_pick })
+  eq("fzf-lua preview decrypts", vim.api.nvim_buf_get_lines(pv3, 0, -1, false), { "secret {{ .x }}" })
+
+  ct.config.picker = "mini"
+  vim.cmd("Chezmoi pick")
+  local pv4 = vim.api.nvim_create_buf(false, true)
+  picked.mini.source.preview(pv4, { path = enc_pick })
+  eq("mini preview decrypts", vim.api.nvim_buf_get_lines(pv4, 0, -1, false), { "secret {{ .x }}" })
+
+  for _, b in ipairs({ pv1, pv2, pv3, pv4 }) do
+    vim.api.nvim_buf_delete(b, { force = true })
+  end
+  os.remove(enc_pick)
+
   ct.config.picker = nil
   local pb2 = vim.fn.bufnr(pick_me)
   if pb2 ~= -1 then
     vim.api.nvim_buf_delete(pb2, { force = true })
   end
   os.remove(pick_me)
+end
+
+-- encryption.text: the read-only decrypt for preview consumers gates on the
+-- same eligibility as the transparent layer
+do
+  local enc = require("chezmoi-template.encryption")
+  ct.config.encryption.exclude = { "skipme" }
+  fake["decrypt"] = { code = 0, stdout = "plain\n" }
+  eq("text decrypts a managed encrypted file", enc.text(SRC .. "/t.age"), "plain\n")
+  eq("text nil for a non-encrypted suffix", enc.text(SRC .. "/t.txt"), nil)
+  eq("text nil outside the source dir", enc.text("/outside/t.age"), nil)
+  eq("text nil for an excluded path", enc.text(SRC .. "/skipme.age"), nil)
+  fake["decrypt"] = { code = 1, stderr = "boom" }
+  eq("text nil when decryption fails", enc.text(SRC .. "/t.age"), nil)
+  ct.config.encryption.enabled = false
+  eq("text nil while encryption is disabled", enc.text(SRC .. "/t.age"), nil)
+  ct.config.encryption.enabled = true
 end
 
 -- inject directive: only runs where the gotmpl parser exists (skipped in CI)


### PR DESCRIPTION
Two picker changes, one breaking.

## Decrypted previews

Preview buffers read the file's raw bytes directly — `BufReadPre` never fires for scratch buffers — so a managed encrypted entry previewed as age/gpg armor. Every backend (snacks, telescope, fzf-lua, mini.pick) now swaps the preview contents for `chezmoi decrypt` output and types the buffer as the deployed target, with `*.tmpl.age` routed through gotmpl so the target language injects, matching what opening the file shows.

Eligibility (encryption enabled, encrypted suffix, not excluded, inside the source dir) is shared with the transparent-encryption autocmds through a new `encryption.text()`, so the picker cannot drift from what decrypt-on-read accepts. Files that are not eligible fall through to each backend's stock previewer unchanged. Each file decrypts once per picker session: every cursor move re-previews, and each decrypt is a chezmoi spawn.

## `picker.exclude` stacks on the defaults

A non-nil `picker.exclude` used to replace the built-in internals list, so hiding a single noisy path cost re-adding `.git/` and friends by hand (or requiring the plugin inside its own spec to reach `DEFAULT_EXCLUDE`). User patterns now hide entries in addition to the defaults:

```lua
picker = {
  exclude = { "^private_dot_ssh/.*id_" }, -- ssh keys out, .ssh/config stays
},
```

`exclude = false` is the new show-everything escape hatch.

**BREAKING CHANGE:** `picker.exclude` no longer replaces the internals defaults, and `exclude = {}` now means "defaults only" rather than "show all". Configs that relied on replacement get the defaults hidden as well; configs that used `{}` to show everything should use `exclude = false`.

## Tests

- All four backend previewers decrypt an encrypted entry; a plain entry falls through to the backend's own previewer
- Decrypt-once-per-session via the spawn counter; `gotmpl` typing and target-ft seeding
- Every `encryption.text()` eligibility branch (disabled, wrong suffix, excluded, unmanaged, failed decrypt)
- Exclude stacking (user pattern and defaults both hidden) and `exclude = false`

`make test` and `stylua --check lua plugin tests` pass.
